### PR TITLE
corrige le problème de package lors d'un mvn install et ou deploy

### DIFF
--- a/portlet-monitor-domain-services/pom.xml
+++ b/portlet-monitor-domain-services/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.esup.portail</groupId>
             <artifactId>portlet-monitor-domain-beans</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/portlet-monitor-web-springmvc-portlet/pom.xml
+++ b/portlet-monitor-web-springmvc-portlet/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.esup.portail</groupId>
             <artifactId>portlet-monitor-domain-services</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
Cela est nécessaire afin de pouvoir deployer sur un serveur nexus le war et dans l'optique de pouvoir intégrer le portlet dans le package esup-uportal via les portlet-overlay.

Merci de faire un mvn deploy une fois le commit intégré, afin d'uploader le portlet-monitor-web-springmvc-portlet-0.1.war sur le serveur de dépot maven d'ESUP.
